### PR TITLE
Remove channel/confinement from snap package manager constructor

### DIFF
--- a/commands/interface.go
+++ b/commands/interface.go
@@ -108,6 +108,11 @@ func NewAptPackageCommander() PackageCommander {
 	return &aptCmder
 }
 
+// NewSnapPackageCommander returns a PackageCommander for snap-based systems.
+func NewSnapPackageCommander() PackageCommander {
+	return &snapCmder
+}
+
 // NewYumPackageCommander returns a PackageCommander for yum-based systems.
 func NewYumPackageCommander() PackageCommander {
 	return &yumCmder

--- a/commands/snap.go
+++ b/commands/snap.go
@@ -11,37 +11,27 @@ const (
 	snapProxySettingFormat   = `proxy.%s=%q`
 )
 
-// NewSnapPackageCommander returns a PackageCommander for snap-based systems.
-func NewSnapPackageCommander(channel, confinement string) PackageCommander {
-	var installArgs string
-	if channel != "" {
-		installArgs += " --" + channel
-	}
-	if confinement != "" {
-		installArgs += " --" + confinement
-	}
-
-	return &packageCommander{
-		prereq:           makeNopCmd(),
-		update:           makeNopCmd(),
-		upgrade:          buildCommand(snapBinary, "refresh"),
-		install:          buildCommand(snapBinary, "install "+installArgs),
-		remove:           buildCommand(snapBinary, "remove"),
-		purge:            buildCommand(snapBinary, "remove"),
-		search:           buildCommand(snapBinary, "info %s"),
-		isInstalled:      buildCommand(snapBinary, "list %s"),
-		listAvailable:    makeNopCmd(),
-		listInstalled:    buildCommand(snapBinary, "list"),
-		addRepository:    makeNopCmd(),
-		listRepositories: makeNopCmd(),
-		removeRepository: makeNopCmd(),
-		cleanup:          makeNopCmd(),
-		// Note: proxy.{http,https} available since snapd 2.28
-		getProxy:              buildCommand(snapBinary, "get system proxy"),
-		proxySettingsFormat:   snapProxySettingFormat,
-		noProxySettingsFormat: snapNoProxySettingFormat,
-		setProxy:              buildCommand(snapBinary, "set system %s"),
-	}
+// snapCmder is the packageCommander instantiation for snap-based systems.
+var snapCmder = packageCommander{
+	prereq:           makeNopCmd(),
+	update:           makeNopCmd(),
+	upgrade:          buildCommand(snapBinary, "refresh"),
+	install:          buildCommand(snapBinary, "install "),
+	remove:           buildCommand(snapBinary, "remove"),
+	purge:            buildCommand(snapBinary, "remove"),
+	search:           buildCommand(snapBinary, "info %s"),
+	isInstalled:      buildCommand(snapBinary, "list %s"),
+	listAvailable:    makeNopCmd(),
+	listInstalled:    buildCommand(snapBinary, "list"),
+	addRepository:    makeNopCmd(),
+	listRepositories: makeNopCmd(),
+	removeRepository: makeNopCmd(),
+	cleanup:          makeNopCmd(),
+	// Note: proxy.{http,https} available since snapd 2.28
+	getProxy:              buildCommand(snapBinary, "get system proxy"),
+	proxySettingsFormat:   snapProxySettingFormat,
+	noProxySettingsFormat: snapNoProxySettingFormat,
+	setProxy:              buildCommand(snapBinary, "set system %s"),
 }
 
 func makeNopCmd() string {

--- a/commands/snap_test.go
+++ b/commands/snap_test.go
@@ -17,7 +17,7 @@ type SnapSuite struct {
 }
 
 func (s *SnapSuite) SetUpSuite(c *gc.C) {
-	s.paccmder = commands.NewSnapPackageCommander("stable", "classic")
+	s.paccmder = commands.NewSnapPackageCommander()
 }
 
 func (s *SnapSuite) TestProxyConfigContentsEmpty(c *gc.C) {

--- a/manager/interface.go
+++ b/manager/interface.go
@@ -90,12 +90,8 @@ func NewAptPackageManager() PackageManager {
 }
 
 // NewSnapPackageManager returns a PackageManager for snap-based systems.
-// Callers can either excplicitly specify the channel and confinement settings
-// for installing snap packages or pass empty values to use snap defaults.
-func NewSnapPackageManager(channel, confinement string) PackageManager {
-	return &snap{basePackageManager{
-		commands.NewSnapPackageCommander(channel, confinement),
-	}}
+func NewSnapPackageManager() PackageManager {
+	return &snap{basePackageManager{commands.NewSnapPackageCommander()}}
 }
 
 // NewYumPackageManager returns a PackageManager for yum-based systems.

--- a/manager/manager_test.go
+++ b/manager/manager_test.go
@@ -29,7 +29,7 @@ type ManagerSuite struct {
 func (s *ManagerSuite) SetUpSuite(c *gc.C) {
 	s.IsolationSuite.SetUpSuite(c)
 	s.apt = manager.NewAptPackageManager()
-	s.snap = manager.NewSnapPackageManager("stable", "classic")
+	s.snap = manager.NewSnapPackageManager()
 	s.yum = manager.NewYumPackageManager()
 	s.zypper = manager.NewZypperPackageManager()
 }
@@ -53,7 +53,7 @@ var (
 
 	// snapCmder is the commands.PackageCommander for snap-based
 	// systems whose commands will be checked against.
-	snapCmder = commands.NewSnapPackageCommander("stable", "classic")
+	snapCmder = commands.NewSnapPackageCommander()
 
 	// yumCmder is the commands.PackageCommander for yum-based
 	// systems whose commands will be checked against.

--- a/manager/snap_test.go
+++ b/manager/snap_test.go
@@ -27,8 +27,8 @@ type SnapSuite struct {
 
 func (s *SnapSuite) SetUpSuite(c *gc.C) {
 	s.IsolationSuite.SetUpSuite(c)
-	s.paccmder = commands.NewSnapPackageCommander("stable", "classic")
-	s.pacman = manager.NewSnapPackageManager("stable", "classic")
+	s.paccmder = commands.NewSnapPackageCommander()
+	s.pacman = manager.NewSnapPackageManager()
 }
 
 func (s *SnapSuite) SetUpTest(c *gc.C) {


### PR DESCRIPTION
The previous PR (#4) introduced a package manager for snap-based systems. An issue with the current implementation is that the constructor for the snap package manager expects arguments for specifying the channel and confinement for snaps. However, these should be specified on a _per-package_ basis.

This PR addresses this issue.