### PR TITLE
Handle snap store proxy assertions when configuring proxy

### DIFF
--- a/manager/interface.go
+++ b/manager/interface.go
@@ -90,8 +90,8 @@ func NewAptPackageManager() PackageManager {
 }
 
 // NewSnapPackageManager returns a PackageManager for snap-based systems.
-func NewSnapPackageManager() PackageManager {
-	return &snap{basePackageManager{commands.NewSnapPackageCommander()}}
+func NewSnapPackageManager() *Snap {
+	return &Snap{basePackageManager{commands.NewSnapPackageCommander()}}
 }
 
 // NewYumPackageManager returns a PackageManager for yum-based systems.

--- a/manager/manager_test.go
+++ b/manager/manager_test.go
@@ -9,7 +9,6 @@ import (
 	"os/exec"
 	"strings"
 
-	"github.com/juju/proxy"
 	"github.com/juju/testing"
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
@@ -70,14 +69,6 @@ var (
 	// testedRepoName is the repository name used in all
 	// repository-related tests.
 	testedRepoName = "some-repo"
-
-	// testedProxySettings is the set of proxy settings used in
-	// all proxy-related tests.
-	testedProxySettings = proxy.Settings{
-		Http:  "http://some-proxy.domain",
-		Https: "https://some-proxy.domain",
-		Ftp:   "ftp://some-proxy.domain",
-	}
 
 	// testedPackageNames is a list of package names used in all
 	// multiple-package testing scenarions.

--- a/manager/snap.go
+++ b/manager/snap.go
@@ -124,6 +124,20 @@ func (snap *Snap) ConfigureStoreProxy(assertions, storeID string) error {
 	return nil
 }
 
+// DisableStoreProxy resets the snapd proxy store settings.
+//
+// If snap was also configured to use HTTP/HTTPS proxies these must be reset
+// separately via a call to SetProxy.
+// call to SetProxy.
+func (snap *Snap) DisableStoreProxy() error {
+	setCmd := "snap set core proxy.store="
+	if _, _, err := RunCommandWithRetry(setCmd, nil); err != nil {
+		return errors.Annotate(err, "failed to configure snap to not use a store proxy")
+	}
+
+	return nil
+}
+
 func combinedOutput(out string, err error) string {
 	res := string(out)
 	if err != nil {

--- a/manager/snap_test.go
+++ b/manager/snap_test.go
@@ -224,6 +224,15 @@ func (s *SnapSuite) TestConfigureProxy(c *gc.C) {
 	c.Assert(setCmd.Args, gc.DeepEquals, []string{"snap", "set", "core", "proxy.store=1234567890STOREIDENTIFIER0123456"})
 }
 
+func (s *SnapSuite) TestDisableStoreProxy(c *gc.C) {
+	cmdChan := s.HookCommandOutput(&manager.CommandOutput, nil, nil)
+	err := s.pacman.DisableStoreProxy()
+	c.Assert(err, gc.IsNil)
+
+	setCmd := <-cmdChan
+	c.Assert(setCmd.Args, gc.DeepEquals, []string{"snap", "set", "core", "proxy.store="})
+}
+
 func (s *SnapSuite) mockExitError(code int) error {
 	err := &exec.ExitError{ProcessState: new(os.ProcessState)}
 	s.PatchValue(&manager.ProcessStateSys, func(*os.ProcessState) interface{} {

--- a/manager/testing/manager.go
+++ b/manager/testing/manager.go
@@ -71,7 +71,13 @@ func (pm *MockPackageManager) Cleanup() error {
 
 // GetProxySettings is defined on the PackageManager interface.
 func (pm *MockPackageManager) GetProxySettings() (proxy.Settings, error) {
-	return proxy.Settings{"http proxy", "https proxy", "ftp proxy", "no proxy", "auto no proxy"}, nil
+	return proxy.Settings{
+		Http:        "http proxy",
+		Https:       "https proxy",
+		Ftp:         "ftp proxy",
+		NoProxy:     "no proxy",
+		AutoNoProxy: "auto no proxy",
+	}, nil
 }
 
 // SetProxy is defined on the PackageManager interface.


### PR DESCRIPTION
While snapd can be configured to use an http/https proxy for talking to the outside world we also need to support use-cases where customers deploy a [snap store proxy](https://docs.ubuntu.com/snap-store-proxy/en/).

To configure snap to use the store proxy (instructions are available [here](https://docs.ubuntu.com/snap-store-proxy/en/devices)) we need to provide an assertion file and a store ID. While the assertion file can be pulled directly from the proxy itself, this is not possible when operating in an air-gapped environment. For such use-cases the solution is to manually provide an assertion file and store ID.

This PR adds the `ConfigureStoreProxy` method to the snap package manager implementation that allows clients to configure a store proxy by providing the assertion file and store ID.

Note that the new method only configures the proxy store settings. Additional configuration of HTTP/HTTPS proxies (if required) still needs to be performed via a call to `SetProxy` (same as with all other package managers)

Finally, a `DisableStoreProxy` method is provided to unset any previously configured proxy store settings.