### PR TITLE
Invert argument order in snap manager's ChangeChannel method

### DIFF
--- a/manager/snap.go
+++ b/manager/snap.go
@@ -65,7 +65,7 @@ func (snap *Snap) InstalledChannel(pack string) string {
 }
 
 // ChangeChannel updates the tracked channel for an installed snap.
-func (snap *Snap) ChangeChannel(channel, pack string) error {
+func (snap *Snap) ChangeChannel(pack, channel string) error {
 	out, _, err := RunCommandWithRetry(fmt.Sprintf("snap refresh --channel %s %s", channel, pack), nil)
 	if err != nil {
 		return err

--- a/manager/snap_test.go
+++ b/manager/snap_test.go
@@ -309,7 +309,7 @@ installed:       2.6.6                                (8594) 68MB classic
 func (s *SnapSuite) TestChangeChannel(c *gc.C) {
 	const expected = `lxd (candidate) 4.0.0 from Canonical✓ refreshed`
 	cmdChan := s.HookCommandOutput(&manager.CommandOutput, []byte(expected), nil)
-	err := s.pacman.ChangeChannel("latest/candidate", "lxd")
+	err := s.pacman.ChangeChannel("lxd", "latest/candidate")
 	c.Assert(err, jc.ErrorIsNil)
 
 	setCmd := <-cmdChan
@@ -319,7 +319,7 @@ func (s *SnapSuite) TestChangeChannel(c *gc.C) {
 func (s *SnapSuite) TestChangeChannelForNotInstalledSnap(c *gc.C) {
 	const expected = `snap "lxd" is not installed`
 	cmdChan := s.HookCommandOutput(&manager.CommandOutput, []byte(expected), nil)
-	err := s.pacman.ChangeChannel("latest/candidate", "lxd")
+	err := s.pacman.ChangeChannel("lxd", "latest/candidate")
 	c.Assert(err, gc.ErrorMatches, "snap not installed")
 
 	setCmd := <-cmdChan


### PR DESCRIPTION
This PR switches the argument order for the `ChangeChannel` method (introduced by #8 ) to `(package, channel)` which reads in a more natural fashion.