### PR TITLE
Simplify RunCommand func

### DIFF
--- a/manager/utils.go
+++ b/manager/utils.go
@@ -35,11 +35,7 @@ var ProcessStateSys = (*os.ProcessState).Sys
 var RunCommand = func(command string, args ...string) (output string, err error) {
 	cmd := exec.Command(command, args...)
 	out, err := cmd.CombinedOutput()
-	output = string(out)
-	if err != nil {
-		return output, err
-	}
-	return output, nil
+	return string(out), err
 }
 
 // exitStatuser is a mini-interface for the ExitStatus() method.


### PR DESCRIPTION
No need to check if err is nil