### PR TITLE
Add support for updating the apt security archive

### DIFF
--- a/commands/apt.go
+++ b/commands/apt.go
@@ -61,12 +61,20 @@ var aptCmder = packageCommander{
 	setProxy:              buildCommand("echo %s >> ", AptConfFilePath),
 	noProxySettingsFormat: aptNoProxySettingFormat,
 	setNoProxy:            buildCommand("echo %s >> ", AptConfFilePath),
-	setMirrorCommands: func(newMirror string) []string {
+	setMirrorCommands: func(newArchiveMirror, newSecurityMirror string) []string {
 		var cmds []string
-		cmds = append(cmds, "old_mirror=$("+config.ExtractAptSource+")")
-		cmds = append(cmds, "new_mirror="+newMirror)
-		cmds = append(cmds, `sed -i s,$old_mirror,$new_mirror, `+config.AptSourcesFile)
-		cmds = append(cmds, renameAptListFilesCommands("$new_mirror", "$old_mirror")...)
+		if newArchiveMirror != "" {
+			cmds = append(cmds, "old_archive_mirror=$("+config.ExtractAptArchiveSource+")")
+			cmds = append(cmds, "new_archive_mirror="+newArchiveMirror)
+			cmds = append(cmds, `sed -i s,$old_archive_mirror,$new_archive_mirror, `+config.AptSourcesFile)
+			cmds = append(cmds, renameAptListFilesCommands("$new_archive_mirror", "$old_archive_mirror")...)
+		}
+		if newSecurityMirror != "" {
+			cmds = append(cmds, "old_security_mirror=$("+config.ExtractAptSecuritySource+")")
+			cmds = append(cmds, "new_security_mirror="+newSecurityMirror)
+			cmds = append(cmds, `sed -i s,$old_security_mirror,$new_security_mirror, `+config.AptSourcesFile)
+			cmds = append(cmds, renameAptListFilesCommands("$new_security_mirror", "$old_security_mirror")...)
+		}
 		return cmds
 	},
 }
@@ -80,9 +88,9 @@ func renameAptListFilesCommands(newMirror, oldMirror string) []string {
 	renameFiles := `
 for old in ${old_prefix}_*; do
     new=$(echo $old | sed s,^$old_prefix,$new_prefix,)
-	if [ -f $old ]; then
+    if [ -f $old ]; then
       mv $old $new
-	fi
+    fi
 done`
 
 	return []string{

--- a/commands/apt_test.go
+++ b/commands/apt_test.go
@@ -60,19 +60,31 @@ Acquire::ftp::Proxy::"local2" "DIRECT";`
 
 func (s *AptSuite) TestSetMirrorCommands(c *gc.C) {
 	expected := `
-old_mirror=$(awk "/^deb .* $(awk -F= '/DISTRIB_CODENAME=/ {gsub(/"/,""); print $2}' /etc/lsb-release) .*main.*\$/{print \$2;exit}" /etc/apt/sources.list)
-new_mirror=http://mirror
-sed -i s,$old_mirror,$new_mirror, /etc/apt/sources.list
-old_prefix=/var/lib/apt/lists/$(echo $old_mirror | sed 's,.*://,,' | sed 's,/$,,' | tr / _)
-new_prefix=/var/lib/apt/lists/$(echo $new_mirror | sed 's,.*://,,' | sed 's,/$,,' | tr / _)
+old_archive_mirror=$(awk "/^deb .* $(awk -F= '/DISTRIB_CODENAME=/ {gsub(/"/,""); print $2}' /etc/lsb-release) .*main.*\$/{print \$2;exit}" /etc/apt/sources.list)
+new_archive_mirror=http://mirror
+sed -i s,$old_archive_mirror,$new_archive_mirror, /etc/apt/sources.list
+old_prefix=/var/lib/apt/lists/$(echo $old_archive_mirror | sed 's,.*://,,' | sed 's,/$,,' | tr / _)
+new_prefix=/var/lib/apt/lists/$(echo $new_archive_mirror | sed 's,.*://,,' | sed 's,/$,,' | tr / _)
 [ "$old_prefix" != "$new_prefix" ] &&
 for old in ${old_prefix}_*; do
     new=$(echo $old | sed s,^$old_prefix,$new_prefix,)
-	if [ -f $old ]; then
+    if [ -f $old ]; then
       mv $old $new
-	fi
+    fi
+done
+old_security_mirror=$(awk "/^deb .* $(awk -F= '/DISTRIB_CODENAME=/ {gsub(/"/,""); print $2}' /etc/lsb-release)-security .*main.*\$/{print \$2;exit}" /etc/apt/sources.list)
+new_security_mirror=http://security-mirror
+sed -i s,$old_security_mirror,$new_security_mirror, /etc/apt/sources.list
+old_prefix=/var/lib/apt/lists/$(echo $old_security_mirror | sed 's,.*://,,' | sed 's,/$,,' | tr / _)
+new_prefix=/var/lib/apt/lists/$(echo $new_security_mirror | sed 's,.*://,,' | sed 's,/$,,' | tr / _)
+[ "$old_prefix" != "$new_prefix" ] &&
+for old in ${old_prefix}_*; do
+    new=$(echo $old | sed s,^$old_prefix,$new_prefix,)
+    if [ -f $old ]; then
+      mv $old $new
+    fi
 done`[1:]
-	cmds := s.paccmder.SetMirrorCommands("http://mirror")
+	cmds := s.paccmder.SetMirrorCommands("http://mirror", "http://security-mirror")
 	output := strings.Join(cmds, "\n")
 	c.Assert(output, gc.Equals, expected)
 }

--- a/commands/commander.go
+++ b/commands/commander.go
@@ -15,27 +15,27 @@ import (
 // the operations that may be required of a package management system.
 // It implements the PackageCommander interface.
 type packageCommander struct {
-	prereq                string                // installs prerequisite repo management package
-	update                string                // updates the local package list
-	upgrade               string                // upgrades all packages
-	install               string                // installs the given packages
-	remove                string                // removes the given packages
-	purge                 string                // removes the given packages along with all data
-	search                string                // searches for the given package
-	isInstalled           string                // checks if a given package is installed
-	listAvailable         string                // lists all packes available
-	listInstalled         string                // lists all installed packages
-	listRepositories      string                // lists all currently configured repositories
-	addRepository         string                // adds the given repository
-	removeRepository      string                // removes the given repository
-	cleanup               string                // cleans up orhaned packages and the package cache
-	getProxy              string                // command for getting the currently set packagemanager proxy
-	proxySettingsFormat   string                // format for proxy setting in package manager config file
-	setProxy              string                // command for adding a proxy setting to the config file
-	setNoProxy            string                // command for adding a no-proxy setting to the config file
-	noProxySettingsFormat string                // format for no-proxy setting in package manager config file
-	proxyLabelInCapital   bool                  // true: proxy labels are in capital letter (e.g. HTTP_PROXY)
-	setMirrorCommands     func(string) []string // updates package manager to use the given mirror
+	prereq                string                        // installs prerequisite repo management package
+	update                string                        // updates the local package list
+	upgrade               string                        // upgrades all packages
+	install               string                        // installs the given packages
+	remove                string                        // removes the given packages
+	purge                 string                        // removes the given packages along with all data
+	search                string                        // searches for the given package
+	isInstalled           string                        // checks if a given package is installed
+	listAvailable         string                        // lists all packes available
+	listInstalled         string                        // lists all installed packages
+	listRepositories      string                        // lists all currently configured repositories
+	addRepository         string                        // adds the given repository
+	removeRepository      string                        // removes the given repository
+	cleanup               string                        // cleans up orhaned packages and the package cache
+	getProxy              string                        // command for getting the currently set packagemanager proxy
+	proxySettingsFormat   string                        // format for proxy setting in package manager config file
+	setProxy              string                        // command for adding a proxy setting to the config file
+	setNoProxy            string                        // command for adding a no-proxy setting to the config file
+	noProxySettingsFormat string                        // format for no-proxy setting in package manager config file
+	proxyLabelInCapital   bool                          // true: proxy labels are in capital letter (e.g. HTTP_PROXY)
+	setMirrorCommands     func(string, string) []string // updates archive and security package manager to use the given mirrors
 }
 
 // InstallPrerequisiteCmd is defined on the PackageCommander interface.
@@ -182,9 +182,9 @@ func (p *packageCommander) SetProxyCmds(settings proxy.Settings) []string {
 }
 
 // SetMirrorCommands is defined on the PackageCommander interface.
-func (p *packageCommander) SetMirrorCommands(mirror string) []string {
+func (p *packageCommander) SetMirrorCommands(archiveMirror, securityMirror string) []string {
 	if p.setMirrorCommands == nil {
 		return nil
 	}
-	return p.setMirrorCommands(mirror)
+	return p.setMirrorCommands(archiveMirror, securityMirror)
 }

--- a/commands/interface.go
+++ b/commands/interface.go
@@ -79,8 +79,8 @@ type PackageCommander interface {
 	// NOTE: output may require some additional filtering.
 	GetProxyCmd() string
 
-	// SetMirrorCommands returns the commands to update the package mirror.
-	SetMirrorCommands(string) []string
+	// SetMirrorCommands returns the commands to update the package archive and security mirrors.
+	SetMirrorCommands(string, string) []string
 
 	// ProxyConfigContents returns the format expected by the package manager
 	// for proxy settings which can be written directly to the config file.

--- a/config/apt_constants.go
+++ b/config/apt_constants.go
@@ -20,11 +20,17 @@ const (
 	// apt configuration files are stored.
 	AptConfigDirectory = "/etc/apt/apt.conf.d"
 
-	// ExtractAptSource is a shell command that will extract the
-	// currently configured APT source location. We assume that
+	// ExtractAptArchiveSource is a shell command that will extract the
+	// currently configured APT archive source location. We assume that
 	// the first source for "main" in the file is the one that
 	// should be replaced throughout the file.
-	ExtractAptSource = `awk "/^deb .* $(awk -F= '/DISTRIB_CODENAME=/ {gsub(/"/,""); print $2}' /etc/lsb-release) .*main.*\$/{print \$2;exit}" ` + AptSourcesFile
+	ExtractAptArchiveSource = `awk "/^deb .* $(awk -F= '/DISTRIB_CODENAME=/ {gsub(/"/,""); print $2}' /etc/lsb-release) .*main.*\$/{print \$2;exit}" ` + AptSourcesFile
+
+	// ExtractAptSecuritySource is a shell command that will extract the
+	// currently configured APT security source location. We assume that
+	// the first source for "main" in the file is the one that
+	// should be replaced throughout the file.
+	ExtractAptSecuritySource = `awk "/^deb .* $(awk -F= '/DISTRIB_CODENAME=/ {gsub(/"/,""); print $2}' /etc/lsb-release)-security .*main.*\$/{print \$2;exit}" ` + AptSourcesFile
 
 	// AptSourceListPrefix is a shell program that translates an
 	// APT source (piped from stdin) to a file prefix. The algorithm


### PR DESCRIPTION
There's 2 apt archives in sources.list - the normal package archive and the security archive.
This PR adds support for updating both archives.