### PR TITLE
Retry snap installs

### DIFF
--- a/commands/apt.go
+++ b/commands/apt.go
@@ -4,7 +4,7 @@
 
 package commands
 
-import "github.com/juju/packaging/config"
+import "github.com/juju/packaging/v2/config"
 
 const (
 	// AptConfFilePath is the full file path for the proxy settings that are

--- a/commands/apt_test.go
+++ b/commands/apt_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/juju/proxy"
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/packaging/commands"
+	"github.com/juju/packaging/v2/commands"
 )
 
 var _ = gc.Suite(&AptSuite{})

--- a/commands/snap_test.go
+++ b/commands/snap_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/juju/proxy"
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/packaging/commands"
+	"github.com/juju/packaging/v2/commands"
 )
 
 var _ = gc.Suite(&SnapSuite{})

--- a/commands/yum_test.go
+++ b/commands/yum_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/juju/proxy"
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/packaging/commands"
+	"github.com/juju/packaging/v2/commands"
 )
 
 var _ = gc.Suite(&YumSuite{})

--- a/commands/zypper_test.go
+++ b/commands/zypper_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/juju/proxy"
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/packaging/commands"
+	"github.com/juju/packaging/v2/commands"
 )
 
 var _ = gc.Suite(&ZypperSuite{})

--- a/config/apt_test.go
+++ b/config/apt_test.go
@@ -10,7 +10,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/packaging/config"
+	"github.com/juju/packaging/v2/config"
 )
 
 var _ = gc.Suite(&AptSuite{})

--- a/config/centos_constants.go
+++ b/config/centos_constants.go
@@ -5,7 +5,7 @@
 package config
 
 import (
-	"github.com/juju/packaging"
+	"github.com/juju/packaging/v2"
 )
 
 const (

--- a/config/configurer_apt.go
+++ b/config/configurer_apt.go
@@ -5,7 +5,7 @@
 package config
 
 import (
-	"github.com/juju/packaging"
+	"github.com/juju/packaging/v2"
 )
 
 // aptConfigurer is the PackagingConfigurer implementation for apt-based systems.

--- a/config/configurer_yum.go
+++ b/config/configurer_yum.go
@@ -5,7 +5,7 @@
 package config
 
 import (
-	"github.com/juju/packaging"
+	"github.com/juju/packaging/v2"
 )
 
 // yumConfigurer is the PackagingConfigurer implementation for apt-based systems.

--- a/config/configurer_zypper.go
+++ b/config/configurer_zypper.go
@@ -5,7 +5,7 @@
 package config
 
 import (
-	"github.com/juju/packaging"
+	"github.com/juju/packaging/v2"
 )
 
 // yumConfigurer is the PackagingConfigurer implementation for apt-based systems.

--- a/config/constants_test.go
+++ b/config/constants_test.go
@@ -4,7 +4,7 @@
 
 package config_test
 
-import "github.com/juju/packaging"
+import "github.com/juju/packaging/v2"
 
 var (
 	// testedSeriesUbuntu is simply the series to use in Ubuntu tests.

--- a/config/functions.go
+++ b/config/functions.go
@@ -5,7 +5,7 @@
 package config
 
 import (
-	"github.com/juju/packaging"
+	"github.com/juju/packaging/v2"
 )
 
 // SeriesRequiresCloudArchiveTools signals whether the given series

--- a/config/functions_test.go
+++ b/config/functions_test.go
@@ -10,8 +10,8 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/packaging"
-	"github.com/juju/packaging/config"
+	"github.com/juju/packaging/v2"
+	"github.com/juju/packaging/v2/config"
 )
 
 var _ = gc.Suite(&FunctionsSuite{})

--- a/config/interface.go
+++ b/config/interface.go
@@ -8,7 +8,7 @@
 package config
 
 import (
-	"github.com/juju/packaging"
+	"github.com/juju/packaging/v2"
 )
 
 // PackagingConfigurer is an interface which handles various packaging-related configuration

--- a/config/interface_test.go
+++ b/config/interface_test.go
@@ -5,7 +5,7 @@
 package config_test
 
 import (
-	"github.com/juju/packaging/config"
+	"github.com/juju/packaging/v2/config"
 )
 
 var _ config.PackagingConfigurer = config.NewAptPackagingConfigurer("some-series")

--- a/config/opensuse_constants.go
+++ b/config/opensuse_constants.go
@@ -5,7 +5,7 @@
 package config
 
 import (
-	"github.com/juju/packaging"
+	"github.com/juju/packaging/v2"
 )
 
 const (

--- a/config/ubuntu_constants.go
+++ b/config/ubuntu_constants.go
@@ -7,7 +7,7 @@ package config
 import (
 	"fmt"
 
-	"github.com/juju/packaging"
+	"github.com/juju/packaging/v2"
 )
 
 const (

--- a/config/yum_test.go
+++ b/config/yum_test.go
@@ -10,7 +10,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/packaging/config"
+	"github.com/juju/packaging/v2/config"
 )
 
 var _ = gc.Suite(&YumSuite{})

--- a/config/zypper_test.go
+++ b/config/zypper_test.go
@@ -9,7 +9,7 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/packaging/config"
+	"github.com/juju/packaging/v2/config"
 )
 
 var _ = gc.Suite(&ZypperSuite{})

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/juju/packaging
+module github.com/juju/packaging/v2
 
 go 1.16
 

--- a/manager/apt.go
+++ b/manager/apt.go
@@ -35,7 +35,8 @@ type apt struct {
 func NewAptPackageManager() PackageManager {
 	manager := &apt{
 		basePackageManager: basePackageManager{
-			cmder: commands.NewAptPackageCommander(),
+			cmder:       commands.NewAptPackageCommander(),
+			retryPolicy: DefaultRetryPolicy(),
 		},
 		installRetryable: makeAPTInstallRetryable(APTExitCode),
 	}
@@ -47,7 +48,7 @@ func NewAptPackageManager() PackageManager {
 
 // Search is defined on the PackageManager interface.
 func (apt *apt) Search(pack string) (bool, error) {
-	out, _, err := RunCommandWithRetry(apt.cmder.SearchCmd(pack), apt)
+	out, _, err := RunCommandWithRetry(apt.cmder.SearchCmd(pack), apt, apt.retryPolicy)
 	if err != nil {
 		return false, err
 	}
@@ -62,7 +63,7 @@ func (apt *apt) Search(pack string) (bool, error) {
 
 // Install is defined on the PackageManager interface.
 func (apt *apt) Install(packs ...string) error {
-	_, _, err := RunCommandWithRetry(apt.cmder.InstallCmd(packs...), apt.installRetryable)
+	_, _, err := RunCommandWithRetry(apt.cmder.InstallCmd(packs...), apt.installRetryable, apt.retryPolicy)
 	return err
 }
 

--- a/manager/apt.go
+++ b/manager/apt.go
@@ -49,7 +49,7 @@ func (apt *apt) Install(packs ...string) error {
 		}
 		return nil
 	}
-	_, _, err := RunCommandWithRetry(apt.cmder.InstallCmd(packs...), fatalErr)
+	_, _, err := RunCommandWithRetry(apt.cmder.InstallCmd(packs...), FatalError(fatalErr))
 	return err
 }
 

--- a/manager/apt_test.go
+++ b/manager/apt_test.go
@@ -12,8 +12,8 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/packaging/commands"
-	"github.com/juju/packaging/manager"
+	"github.com/juju/packaging/v2/commands"
+	"github.com/juju/packaging/v2/manager"
 )
 
 var _ = gc.Suite(&AptSuite{})

--- a/manager/interface.go
+++ b/manager/interface.go
@@ -10,7 +10,7 @@ package manager
 import (
 	"github.com/juju/proxy"
 
-	"github.com/juju/packaging/commands"
+	"github.com/juju/packaging/v2/commands"
 )
 
 // PackageManager is the interface which carries out various

--- a/manager/interface.go
+++ b/manager/interface.go
@@ -9,8 +9,6 @@ package manager
 
 import (
 	"github.com/juju/proxy"
-
-	"github.com/juju/packaging/v2/commands"
 )
 
 // PackageManager is the interface which carries out various
@@ -82,23 +80,4 @@ func NewPackageManager(series string) (PackageManager, error) {
 	default:
 		return NewAptPackageManager(), nil
 	}
-}
-
-// NewAptPackageManager returns a PackageManager for apt-based systems.
-func NewAptPackageManager() PackageManager {
-	return &apt{basePackageManager{commands.NewAptPackageCommander()}}
-}
-
-// NewSnapPackageManager returns a PackageManager for snap-based systems.
-func NewSnapPackageManager() *Snap {
-	return &Snap{basePackageManager{commands.NewSnapPackageCommander()}}
-}
-
-// NewYumPackageManager returns a PackageManager for yum-based systems.
-func NewYumPackageManager() PackageManager {
-	return &yum{basePackageManager{commands.NewYumPackageCommander()}}
-}
-
-func NewZypperPackageManager() PackageManager {
-	return &zypper{basePackageManager{commands.NewZypperPackageCommander()}}
 }

--- a/manager/interface.go
+++ b/manager/interface.go
@@ -13,6 +13,11 @@ import (
 
 // PackageManager is the interface which carries out various
 // package-management related work.
+//
+// TODO (stickupid): Both the PackageManager and PackageCommander from the
+// commands package should be merged. The layout of the packaging package is
+// over-engineered. The commands should be placed directly into the package
+// types themselves and then the managers could be a lot more simpler.
 type PackageManager interface {
 	// InstallPrerequisite runs the command which installs the prerequisite
 	// package which provides repository management functionalityes.

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -16,43 +16,43 @@ import (
 // basePackageManager is the struct which executes various
 // packaging-related operations.
 type basePackageManager struct {
-	retryable Retryable
 	cmder     commands.PackageCommander
+	retryable Retryable
 }
 
 // InstallPrerequisite is defined on the PackageManager interface.
 func (pm *basePackageManager) InstallPrerequisite() error {
-	_, _, err := RunCommandWithRetry(pm.cmder.InstallPrerequisiteCmd(), pm.retryable)
+	_, _, err := RunCommandWithRetry(pm.cmder.InstallPrerequisiteCmd(), pm)
 	return err
 }
 
 // Update is defined on the PackageManager interface.
 func (pm *basePackageManager) Update() error {
-	_, _, err := RunCommandWithRetry(pm.cmder.UpdateCmd(), pm.retryable)
+	_, _, err := RunCommandWithRetry(pm.cmder.UpdateCmd(), pm)
 	return err
 }
 
 // Upgrade is defined on the PackageManager interface.
 func (pm *basePackageManager) Upgrade() error {
-	_, _, err := RunCommandWithRetry(pm.cmder.UpgradeCmd(), pm.retryable)
+	_, _, err := RunCommandWithRetry(pm.cmder.UpgradeCmd(), pm)
 	return err
 }
 
 // Install is defined on the PackageManager interface.
 func (pm *basePackageManager) Install(packs ...string) error {
-	_, _, err := RunCommandWithRetry(pm.cmder.InstallCmd(packs...), pm.retryable)
+	_, _, err := RunCommandWithRetry(pm.cmder.InstallCmd(packs...), pm)
 	return err
 }
 
 // Remove is defined on the PackageManager interface.
 func (pm *basePackageManager) Remove(packs ...string) error {
-	_, _, err := RunCommandWithRetry(pm.cmder.RemoveCmd(packs...), pm.retryable)
+	_, _, err := RunCommandWithRetry(pm.cmder.RemoveCmd(packs...), pm)
 	return err
 }
 
 // Purge is defined on the PackageManager interface.
 func (pm *basePackageManager) Purge(packs ...string) error {
-	_, _, err := RunCommandWithRetry(pm.cmder.PurgeCmd(packs...), pm.retryable)
+	_, _, err := RunCommandWithRetry(pm.cmder.PurgeCmd(packs...), pm)
 	return err
 }
 
@@ -66,19 +66,19 @@ func (pm *basePackageManager) IsInstalled(pack string) bool {
 
 // AddRepository is defined on the PackageManager interface.
 func (pm *basePackageManager) AddRepository(repo string) error {
-	_, _, err := RunCommandWithRetry(pm.cmder.AddRepositoryCmd(repo), pm.retryable)
+	_, _, err := RunCommandWithRetry(pm.cmder.AddRepositoryCmd(repo), pm)
 	return err
 }
 
 // RemoveRepository is defined on the PackageManager interface.
 func (pm *basePackageManager) RemoveRepository(repo string) error {
-	_, _, err := RunCommandWithRetry(pm.cmder.RemoveRepositoryCmd(repo), pm.retryable)
+	_, _, err := RunCommandWithRetry(pm.cmder.RemoveRepositoryCmd(repo), pm)
 	return err
 }
 
 // Cleanup is defined on the PackageManager interface.
 func (pm *basePackageManager) Cleanup() error {
-	_, _, err := RunCommandWithRetry(pm.cmder.CleanupCmd(), pm.retryable)
+	_, _, err := RunCommandWithRetry(pm.cmder.CleanupCmd(), pm)
 	return err
 }
 
@@ -94,4 +94,11 @@ func (pm *basePackageManager) SetProxy(settings proxy.Settings) error {
 	}
 
 	return nil
+}
+
+func (pm *basePackageManager) IsRetryable(code int, output string) bool {
+	if pm.retryable != nil {
+		return pm.retryable.IsRetryable(code, output)
+	}
+	return false
 }

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -16,43 +16,44 @@ import (
 // basePackageManager is the struct which executes various
 // packaging-related operations.
 type basePackageManager struct {
-	cmder     commands.PackageCommander
-	retryable Retryable
+	cmder       commands.PackageCommander
+	retryable   Retryable
+	retryPolicy RetryPolicy
 }
 
 // InstallPrerequisite is defined on the PackageManager interface.
 func (pm *basePackageManager) InstallPrerequisite() error {
-	_, _, err := RunCommandWithRetry(pm.cmder.InstallPrerequisiteCmd(), pm)
+	_, _, err := RunCommandWithRetry(pm.cmder.InstallPrerequisiteCmd(), pm, pm.retryPolicy)
 	return err
 }
 
 // Update is defined on the PackageManager interface.
 func (pm *basePackageManager) Update() error {
-	_, _, err := RunCommandWithRetry(pm.cmder.UpdateCmd(), pm)
+	_, _, err := RunCommandWithRetry(pm.cmder.UpdateCmd(), pm, pm.retryPolicy)
 	return err
 }
 
 // Upgrade is defined on the PackageManager interface.
 func (pm *basePackageManager) Upgrade() error {
-	_, _, err := RunCommandWithRetry(pm.cmder.UpgradeCmd(), pm)
+	_, _, err := RunCommandWithRetry(pm.cmder.UpgradeCmd(), pm, pm.retryPolicy)
 	return err
 }
 
 // Install is defined on the PackageManager interface.
 func (pm *basePackageManager) Install(packs ...string) error {
-	_, _, err := RunCommandWithRetry(pm.cmder.InstallCmd(packs...), pm)
+	_, _, err := RunCommandWithRetry(pm.cmder.InstallCmd(packs...), pm, pm.retryPolicy)
 	return err
 }
 
 // Remove is defined on the PackageManager interface.
 func (pm *basePackageManager) Remove(packs ...string) error {
-	_, _, err := RunCommandWithRetry(pm.cmder.RemoveCmd(packs...), pm)
+	_, _, err := RunCommandWithRetry(pm.cmder.RemoveCmd(packs...), pm, pm.retryPolicy)
 	return err
 }
 
 // Purge is defined on the PackageManager interface.
 func (pm *basePackageManager) Purge(packs ...string) error {
-	_, _, err := RunCommandWithRetry(pm.cmder.PurgeCmd(packs...), pm)
+	_, _, err := RunCommandWithRetry(pm.cmder.PurgeCmd(packs...), pm, pm.retryPolicy)
 	return err
 }
 
@@ -66,19 +67,19 @@ func (pm *basePackageManager) IsInstalled(pack string) bool {
 
 // AddRepository is defined on the PackageManager interface.
 func (pm *basePackageManager) AddRepository(repo string) error {
-	_, _, err := RunCommandWithRetry(pm.cmder.AddRepositoryCmd(repo), pm)
+	_, _, err := RunCommandWithRetry(pm.cmder.AddRepositoryCmd(repo), pm, pm.retryPolicy)
 	return err
 }
 
 // RemoveRepository is defined on the PackageManager interface.
 func (pm *basePackageManager) RemoveRepository(repo string) error {
-	_, _, err := RunCommandWithRetry(pm.cmder.RemoveRepositoryCmd(repo), pm)
+	_, _, err := RunCommandWithRetry(pm.cmder.RemoveRepositoryCmd(repo), pm, pm.retryPolicy)
 	return err
 }
 
 // Cleanup is defined on the PackageManager interface.
 func (pm *basePackageManager) Cleanup() error {
-	_, _, err := RunCommandWithRetry(pm.cmder.CleanupCmd(), pm)
+	_, _, err := RunCommandWithRetry(pm.cmder.CleanupCmd(), pm, pm.retryPolicy)
 	return err
 }
 

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/juju/proxy"
 
-	"github.com/juju/packaging/commands"
+	"github.com/juju/packaging/v2/commands"
 )
 
 // basePackageManager is the struct which executes various

--- a/manager/manager.go
+++ b/manager/manager.go
@@ -16,42 +16,43 @@ import (
 // basePackageManager is the struct which executes various
 // packaging-related operations.
 type basePackageManager struct {
-	cmder commands.PackageCommander
+	retryable Retryable
+	cmder     commands.PackageCommander
 }
 
 // InstallPrerequisite is defined on the PackageManager interface.
 func (pm *basePackageManager) InstallPrerequisite() error {
-	_, _, err := RunCommandWithRetry(pm.cmder.InstallPrerequisiteCmd(), nil)
+	_, _, err := RunCommandWithRetry(pm.cmder.InstallPrerequisiteCmd(), pm.retryable)
 	return err
 }
 
 // Update is defined on the PackageManager interface.
 func (pm *basePackageManager) Update() error {
-	_, _, err := RunCommandWithRetry(pm.cmder.UpdateCmd(), nil)
+	_, _, err := RunCommandWithRetry(pm.cmder.UpdateCmd(), pm.retryable)
 	return err
 }
 
 // Upgrade is defined on the PackageManager interface.
 func (pm *basePackageManager) Upgrade() error {
-	_, _, err := RunCommandWithRetry(pm.cmder.UpgradeCmd(), nil)
+	_, _, err := RunCommandWithRetry(pm.cmder.UpgradeCmd(), pm.retryable)
 	return err
 }
 
 // Install is defined on the PackageManager interface.
 func (pm *basePackageManager) Install(packs ...string) error {
-	_, _, err := RunCommandWithRetry(pm.cmder.InstallCmd(packs...), nil)
+	_, _, err := RunCommandWithRetry(pm.cmder.InstallCmd(packs...), pm.retryable)
 	return err
 }
 
 // Remove is defined on the PackageManager interface.
 func (pm *basePackageManager) Remove(packs ...string) error {
-	_, _, err := RunCommandWithRetry(pm.cmder.RemoveCmd(packs...), nil)
+	_, _, err := RunCommandWithRetry(pm.cmder.RemoveCmd(packs...), pm.retryable)
 	return err
 }
 
 // Purge is defined on the PackageManager interface.
 func (pm *basePackageManager) Purge(packs ...string) error {
-	_, _, err := RunCommandWithRetry(pm.cmder.PurgeCmd(packs...), nil)
+	_, _, err := RunCommandWithRetry(pm.cmder.PurgeCmd(packs...), pm.retryable)
 	return err
 }
 
@@ -65,27 +66,25 @@ func (pm *basePackageManager) IsInstalled(pack string) bool {
 
 // AddRepository is defined on the PackageManager interface.
 func (pm *basePackageManager) AddRepository(repo string) error {
-	_, _, err := RunCommandWithRetry(pm.cmder.AddRepositoryCmd(repo), nil)
+	_, _, err := RunCommandWithRetry(pm.cmder.AddRepositoryCmd(repo), pm.retryable)
 	return err
 }
 
 // RemoveRepository is defined on the PackageManager interface.
 func (pm *basePackageManager) RemoveRepository(repo string) error {
-	_, _, err := RunCommandWithRetry(pm.cmder.RemoveRepositoryCmd(repo), nil)
+	_, _, err := RunCommandWithRetry(pm.cmder.RemoveRepositoryCmd(repo), pm.retryable)
 	return err
 }
 
 // Cleanup is defined on the PackageManager interface.
 func (pm *basePackageManager) Cleanup() error {
-	_, _, err := RunCommandWithRetry(pm.cmder.CleanupCmd(), nil)
+	_, _, err := RunCommandWithRetry(pm.cmder.CleanupCmd(), pm.retryable)
 	return err
 }
 
 // SetProxy is defined on the PackageManager interface.
 func (pm *basePackageManager) SetProxy(settings proxy.Settings) error {
-	cmds := pm.cmder.SetProxyCmds(settings)
-
-	for _, cmd := range cmds {
+	for _, cmd := range pm.cmder.SetProxyCmds(settings) {
 		args := []string{"bash", "-c", fmt.Sprintf("%q", cmd)}
 		out, err := RunCommand(args[0], args[1:]...)
 		if err != nil {

--- a/manager/manager_test.go
+++ b/manager/manager_test.go
@@ -82,8 +82,8 @@ var (
 // getMockRunCommandWithRetry returns a function with the same signature as
 // RunCommandWithRetry which saves the command it recieves in the provided
 // string whilst always returning no output, 0 error code and nil error.
-func getMockRunCommandWithRetry(stor *string) func(string, func(string) error) (string, int, error) {
-	return func(cmd string, fatalErr func(string) error) (string, int, error) {
+func getMockRunCommandWithRetry(stor *string) func(string, func(error, int, string) (bool, error)) (string, int, error) {
+	return func(cmd string, fatalErr func(error, int, string) (bool, error)) (string, int, error) {
 		*stor = cmd
 		return "", 0, nil
 	}
@@ -267,7 +267,7 @@ var simpleTestCases = []*simpleTestCase{
 // given package; either localy or remotely, and need to be tested seperately
 // on the case of their return value being a boolean.
 var searchingTestCases = []*simpleTestCase{
-	&simpleTestCase{
+	{
 		"Test package search.",
 		aptCmder.SearchCmd(testedPackageName),
 		false,
@@ -281,7 +281,7 @@ var searchingTestCases = []*simpleTestCase{
 			return pacman.Search(testedPackageName)
 		},
 	},
-	&simpleTestCase{
+	{
 		"Test local package search.",
 		aptCmder.IsInstalledCmd(testedPackageName),
 		true,

--- a/manager/manager_test.go
+++ b/manager/manager_test.go
@@ -82,8 +82,8 @@ var (
 // getMockRunCommandWithRetry returns a function with the same signature as
 // RunCommandWithRetry which saves the command it recieves in the provided
 // string whilst always returning no output, 0 error code and nil error.
-func getMockRunCommandWithRetry(stor *string) func(string, manager.Retryable) (string, int, error) {
-	return func(cmd string, _ manager.Retryable) (string, int, error) {
+func getMockRunCommandWithRetry(stor *string) func(string, manager.Retryable, manager.RetryPolicy) (string, int, error) {
+	return func(cmd string, _ manager.Retryable, _ manager.RetryPolicy) (string, int, error) {
 		*stor = cmd
 		return "", 0, nil
 	}

--- a/manager/manager_test.go
+++ b/manager/manager_test.go
@@ -13,8 +13,8 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/packaging/commands"
-	"github.com/juju/packaging/manager"
+	"github.com/juju/packaging/v2/commands"
+	"github.com/juju/packaging/v2/manager"
 )
 
 var _ = gc.Suite(&ManagerSuite{})

--- a/manager/manager_test.go
+++ b/manager/manager_test.go
@@ -82,8 +82,8 @@ var (
 // getMockRunCommandWithRetry returns a function with the same signature as
 // RunCommandWithRetry which saves the command it recieves in the provided
 // string whilst always returning no output, 0 error code and nil error.
-func getMockRunCommandWithRetry(stor *string) func(string, func(error, int, string) (bool, error)) (string, int, error) {
-	return func(cmd string, fatalErr func(error, int, string) (bool, error)) (string, int, error) {
+func getMockRunCommandWithRetry(stor *string) func(string, manager.Retryable) (string, int, error) {
+	return func(cmd string, _ manager.Retryable) (string, int, error) {
 		*stor = cmd
 		return "", 0, nil
 	}
@@ -135,7 +135,7 @@ type simpleTestCase struct {
 }
 
 var simpleTestCases = []*simpleTestCase{
-	&simpleTestCase{
+	{
 		"Test install prerequisites.",
 		aptCmder.InstallPrerequisiteCmd(),
 		nil,
@@ -149,7 +149,7 @@ var simpleTestCases = []*simpleTestCase{
 			return nil, pacman.InstallPrerequisite()
 		},
 	},
-	&simpleTestCase{
+	{
 		"Test system update.",
 		aptCmder.UpdateCmd(),
 		nil,
@@ -163,7 +163,7 @@ var simpleTestCases = []*simpleTestCase{
 			return nil, pacman.Update()
 		},
 	},
-	&simpleTestCase{
+	{
 		"Test system upgrade.",
 		aptCmder.UpgradeCmd(),
 		nil,
@@ -177,7 +177,7 @@ var simpleTestCases = []*simpleTestCase{
 			return nil, pacman.Upgrade()
 		},
 	},
-	&simpleTestCase{
+	{
 		"Test install packages.",
 		aptCmder.InstallCmd(testedPackageNames...),
 		nil,
@@ -191,7 +191,7 @@ var simpleTestCases = []*simpleTestCase{
 			return nil, pacman.Install(testedPackageNames...)
 		},
 	},
-	&simpleTestCase{
+	{
 		"Test remove packages.",
 		aptCmder.RemoveCmd(testedPackageNames...),
 		nil,
@@ -205,7 +205,7 @@ var simpleTestCases = []*simpleTestCase{
 			return nil, pacman.Remove(testedPackageNames...)
 		},
 	},
-	&simpleTestCase{
+	{
 		"Test purge packages.",
 		aptCmder.PurgeCmd(testedPackageNames...),
 		nil,
@@ -219,7 +219,7 @@ var simpleTestCases = []*simpleTestCase{
 			return nil, pacman.Purge(testedPackageNames...)
 		},
 	},
-	&simpleTestCase{
+	{
 		"Test repository addition.",
 		aptCmder.AddRepositoryCmd(testedRepoName),
 		nil,
@@ -233,7 +233,7 @@ var simpleTestCases = []*simpleTestCase{
 			return nil, pacman.AddRepository(testedRepoName)
 		},
 	},
-	&simpleTestCase{
+	{
 		"Test repository removal.",
 		aptCmder.RemoveRepositoryCmd(testedRepoName),
 		nil,
@@ -247,7 +247,7 @@ var simpleTestCases = []*simpleTestCase{
 			return nil, pacman.RemoveRepository(testedRepoName)
 		},
 	},
-	&simpleTestCase{
+	{
 		"Test running cleanup.",
 		aptCmder.CleanupCmd(),
 		nil,

--- a/manager/run_test.go
+++ b/manager/run_test.go
@@ -15,25 +15,25 @@ import (
 	"github.com/juju/packaging/v2/manager"
 )
 
-var _ = gc.Suite(&UtilsSuite{})
+var _ = gc.Suite(&RunSuite{})
 
-type UtilsSuite struct {
+type RunSuite struct {
 	testing.IsolationSuite
 }
 
-func (s *UtilsSuite) SetUpSuite(c *gc.C) {
+func (s *RunSuite) SetUpSuite(c *gc.C) {
 	s.IsolationSuite.SetUpSuite(c)
 }
 
-func (s *UtilsSuite) SetUpTest(c *gc.C) {
+func (s *RunSuite) SetUpTest(c *gc.C) {
 	s.IsolationSuite.SetUpTest(c)
 }
 
-func (s *UtilsSuite) TearDownTest(c *gc.C) {
+func (s *RunSuite) TearDownTest(c *gc.C) {
 	s.IsolationSuite.TearDownTest(c)
 }
 
-func (s *UtilsSuite) TearDownSuite(c *gc.C) {
+func (s *RunSuite) TearDownSuite(c *gc.C) {
 	s.IsolationSuite.TearDownSuite(c)
 }
 
@@ -43,7 +43,7 @@ func (es mockExitStatuser) ExitStatus() int {
 	return int(es)
 }
 
-func (s *UtilsSuite) TestRunCommandWithRetryDoesNotCallCombinedOutputTwice(c *gc.C) {
+func (s *RunSuite) TestRunCommandWithRetryDoesOnPackageLocationFailure(c *gc.C) {
 	const minRetries = 3
 	var calls int
 	state := os.ProcessState{}
@@ -65,11 +65,11 @@ func (s *UtilsSuite) TestRunCommandWithRetryDoesNotCallCombinedOutputTwice(c *gc
 			c.Check(err, gc.ErrorMatches, "exec: Stdout already set")
 			c.Fatalf("CommandOutput called twice unexpectedly")
 		}
-		return output, cmdError
+		return []byte(output), cmdError
 	})
 
+	calls = 0
 	apt := manager.NewAptPackageManager()
-
 	err := apt.Install(testedPackageName)
 	c.Check(err, gc.ErrorMatches, "packaging command failed: attempt count exceeded: exit status.*")
 	c.Check(calls, gc.Equals, minRetries)
@@ -80,16 +80,33 @@ func (s *UtilsSuite) TestRunCommandWithRetryDoesNotCallCombinedOutputTwice(c *gc
 	err = yum.Install(testedPackageName)
 	c.Check(err, gc.ErrorMatches, "packaging command failed: attempt count exceeded: exit status.*")
 	c.Check(calls, gc.Equals, minRetries)
-
-	// reset calls and re-test for Zypper calls:
-	calls = 0
-	zypper := manager.NewZypperPackageManager()
-	err = zypper.Install(testedPackageName)
-	c.Check(err, gc.ErrorMatches, "packaging command failed: attempt count exceeded: exit status.*")
-	c.Check(calls, gc.Equals, minRetries)
 }
 
-func (s *UtilsSuite) TestRunCommandWithRetryStopsWithFatalError(c *gc.C) {
+func (s *RunSuite) TestRunCommandWithRetryDoesNotRetryZappierOnPackageLocationFailure(c *gc.C) {
+	const minRetries = 3
+	var calls int
+	state := os.ProcessState{}
+	cmdError := &exec.ExitError{ProcessState: &state}
+	s.PatchValue(&manager.Attempts, minRetries)
+	s.PatchValue(&manager.Delay, testing.ShortWait)
+	s.PatchValue(&manager.ProcessStateSys, func(*os.ProcessState) interface{} {
+		return mockExitStatuser(100) // retry each time.
+	})
+	s.PatchValue(&manager.CommandOutput, func(cmd *exec.Cmd) ([]byte, error) {
+		calls++
+		cmdOutput := fmt.Sprintf("Reading state information...\nE: Unable to locate package %s",
+
+			testedPackageName)
+		return []byte(cmdOutput), cmdError
+	})
+
+	zypper := manager.NewZypperPackageManager()
+	err := zypper.Install(testedPackageName)
+	c.Check(err, gc.ErrorMatches, "packaging command failed: exit status.*")
+	c.Check(calls, gc.Equals, 1)
+}
+
+func (s *RunSuite) TestRunCommandWithRetryStopsWithFatalError(c *gc.C) {
 	const minRetries = 3
 	var calls int
 	state := os.ProcessState{}

--- a/manager/snap.go
+++ b/manager/snap.go
@@ -18,10 +18,13 @@ import (
 const (
 	// SnapExitCode is used to indicate a retryable failure for Snap.
 	// See list of failures.
-	SnapExitCode int = 1
+	SnapExitCode = 1
 )
 
 var (
+	// SnapAttempts describe the number of attempts to retry each command.
+	SnapAttempts = 3
+
 	// snapProxyRe is a regexp which matches all proxy-related configuration
 	// options in the snap proxy settings output
 	snapProxyRE = regexp.MustCompile(`(?im)^proxy\.(?P<protocol>[a-z]+)\s+(?P<proxy>.+)$`)
@@ -43,6 +46,10 @@ func NewSnapPackageManager() *Snap {
 	return &Snap{
 		basePackageManager: basePackageManager{
 			cmder: commands.NewSnapPackageCommander(),
+			retryPolicy: RetryPolicy{
+				Delay:    Delay,
+				Attempts: SnapAttempts,
+			},
 		},
 		// InstallRetryable checks a series of strings, to pattern
 		// match against the cmd output to see if an install command is
@@ -55,7 +62,7 @@ func NewSnapPackageManager() *Snap {
 
 // Search is defined on the PackageManager interface.
 func (snap *Snap) Search(pack string) (bool, error) {
-	out, _, err := RunCommandWithRetry(snap.cmder.SearchCmd(pack), snap)
+	out, _, err := RunCommandWithRetry(snap.cmder.SearchCmd(pack), snap, snap.retryPolicy)
 	if strings.Contains(combinedOutput(out, err), "error: no snap found") {
 		return false, nil
 	} else if err != nil {
@@ -67,7 +74,7 @@ func (snap *Snap) Search(pack string) (bool, error) {
 
 // IsInstalled is defined on the PackageManager interface.
 func (snap *Snap) IsInstalled(pack string) bool {
-	out, _, err := RunCommandWithRetry(snap.cmder.IsInstalledCmd(pack), snap)
+	out, _, err := RunCommandWithRetry(snap.cmder.IsInstalledCmd(pack), snap, snap.retryPolicy)
 	if strings.Contains(combinedOutput(out, err), "error: no matching snaps installed") || err != nil {
 		return false
 	}
@@ -76,7 +83,7 @@ func (snap *Snap) IsInstalled(pack string) bool {
 
 // InstalledChannel returns the snap channel for an installed package.
 func (snap *Snap) InstalledChannel(pack string) string {
-	out, _, err := RunCommandWithRetry(fmt.Sprintf("snap info %s", pack), snap)
+	out, _, err := RunCommandWithRetry(fmt.Sprintf("snap info %s", pack), snap, snap.retryPolicy)
 	combined := combinedOutput(out, err)
 	matches := trackingRE.FindAllStringSubmatch(combined, 1)
 	if len(matches) == 0 {
@@ -88,7 +95,8 @@ func (snap *Snap) InstalledChannel(pack string) string {
 
 // ChangeChannel updates the tracked channel for an installed snap.
 func (snap *Snap) ChangeChannel(pack, channel string) error {
-	out, _, err := RunCommandWithRetry(fmt.Sprintf("snap refresh --channel %s %s", channel, pack), snap)
+	cmd := fmt.Sprintf("snap refresh --channel %s %s", channel, pack)
+	out, _, err := RunCommandWithRetry(cmd, snap, snap.retryPolicy)
 	if err != nil {
 		return err
 	} else if strings.Contains(combinedOutput(out, err), "not installed") {
@@ -100,7 +108,7 @@ func (snap *Snap) ChangeChannel(pack, channel string) error {
 
 // Install is defined on the PackageManager interface.
 func (snap *Snap) Install(packs ...string) error {
-	out, _, err := RunCommandWithRetry(snap.cmder.InstallCmd(packs...), snap.installRetryable)
+	out, _, err := RunCommandWithRetry(snap.cmder.InstallCmd(packs...), snap.installRetryable, snap.retryPolicy)
 	if snapNotFoundRE.MatchString(combinedOutput(out, err)) {
 		return errors.New("unable to locate package")
 	}
@@ -111,7 +119,7 @@ func (snap *Snap) Install(packs ...string) error {
 func (snap *Snap) GetProxySettings() (proxy.Settings, error) {
 	var res proxy.Settings
 
-	out, _, err := RunCommandWithRetry(snap.cmder.GetProxyCmd(), snap)
+	out, _, err := RunCommandWithRetry(snap.cmder.GetProxyCmd(), snap, snap.retryPolicy)
 	if strings.Contains(combinedOutput(out, err), `no "proxy" configuration option`) {
 		return res, nil
 	} else if err != nil {
@@ -159,12 +167,12 @@ func (snap *Snap) ConfigureStoreProxy(assertions, storeID string) error {
 	_ = assertFile.Close()
 
 	ackCmd := fmt.Sprintf("snap ack %s", assertFile.Name())
-	if _, _, err = RunCommandWithRetry(ackCmd, snap); err != nil {
+	if _, _, err = RunCommandWithRetry(ackCmd, snap, snap.retryPolicy); err != nil {
 		return errors.Annotate(err, "failed to execute 'snap ack'")
 	}
 
 	setCmd := fmt.Sprintf("snap set system proxy.store=%s", storeID)
-	if _, _, err = RunCommandWithRetry(setCmd, snap); err != nil {
+	if _, _, err = RunCommandWithRetry(setCmd, snap, snap.retryPolicy); err != nil {
 		return errors.Annotatef(err, "failed to configure snap to use store ID %q", storeID)
 	}
 
@@ -178,7 +186,7 @@ func (snap *Snap) ConfigureStoreProxy(assertions, storeID string) error {
 // call to SetProxy.
 func (snap *Snap) DisableStoreProxy() error {
 	setCmd := "snap set system proxy.store="
-	if _, _, err := RunCommandWithRetry(setCmd, snap); err != nil {
+	if _, _, err := RunCommandWithRetry(setCmd, snap, snap.retryPolicy); err != nil {
 		return errors.Annotate(err, "failed to configure snap to not use a store proxy")
 	}
 

--- a/manager/snap_test.go
+++ b/manager/snap_test.go
@@ -61,26 +61,6 @@ DATA...
 
 type SnapSuite struct {
 	testing.IsolationSuite
-	paccmder commands.PackageCommander
-	pacman   *manager.Snap
-}
-
-func (s *SnapSuite) SetUpSuite(c *gc.C) {
-	s.IsolationSuite.SetUpSuite(c)
-	s.paccmder = commands.NewSnapPackageCommander()
-	s.pacman = manager.NewSnapPackageManager()
-}
-
-func (s *SnapSuite) SetUpTest(c *gc.C) {
-	s.IsolationSuite.SetUpTest(c)
-}
-
-func (s *SnapSuite) TearDownTest(c *gc.C) {
-	s.IsolationSuite.TearDownTest(c)
-}
-
-func (s *SnapSuite) TearDownSuite(c *gc.C) {
-	s.IsolationSuite.TearDownSuite(c)
 }
 
 func (s *SnapSuite) TestGetProxySettingsEmpty(c *gc.C) {
@@ -88,11 +68,13 @@ func (s *SnapSuite) TestGetProxySettingsEmpty(c *gc.C) {
 
 	cmdChan := s.HookCommandOutput(&manager.CommandOutput, []byte(expected), s.mockExitError(1))
 
-	out, err := s.pacman.GetProxySettings()
+	paccmder := commands.NewSnapPackageCommander()
+	pacman := manager.NewSnapPackageManager()
+	out, err := pacman.GetProxySettings()
 	c.Assert(err, jc.ErrorIsNil)
 
 	cmd := <-cmdChan
-	c.Assert(cmd.Args, gc.DeepEquals, strings.Fields(s.paccmder.GetProxyCmd()))
+	c.Assert(cmd.Args, gc.DeepEquals, strings.Fields(paccmder.GetProxyCmd()))
 	c.Assert(out, gc.Equals, proxy.Settings{})
 }
 
@@ -103,11 +85,13 @@ proxy.https  localhost:8181
 proxy.ftp  localhost:2121`
 	cmdChan := s.HookCommandOutput(&manager.CommandOutput, []byte(expected), nil)
 
-	out, err := s.pacman.GetProxySettings()
+	paccmder := commands.NewSnapPackageCommander()
+	pacman := manager.NewSnapPackageManager()
+	out, err := pacman.GetProxySettings()
 	c.Assert(err, gc.IsNil)
 
 	cmd := <-cmdChan
-	c.Assert(cmd.Args, gc.DeepEquals, strings.Fields(s.paccmder.GetProxyCmd()))
+	c.Assert(cmd.Args, gc.DeepEquals, strings.Fields(paccmder.GetProxyCmd()))
 
 	c.Assert(out, gc.Equals, proxy.Settings{
 		Http:  "localhost:8080",
@@ -146,24 +130,30 @@ channels:
 installed:       2.6.6                                (8594) 68MB classic
 `
 	cmdChan := s.HookCommandOutput(&manager.CommandOutput, []byte(expected), nil)
-	exists, err := s.pacman.Search("juju")
+
+	paccmder := commands.NewSnapPackageCommander()
+	pacman := manager.NewSnapPackageManager()
+	exists, err := pacman.Search("juju")
 	c.Assert(err, gc.IsNil)
 	c.Assert(exists, jc.IsTrue)
 
 	cmd := <-cmdChan
-	c.Assert(cmd.Args, gc.DeepEquals, strings.Fields(s.paccmder.SearchCmd("juju")))
+	c.Assert(cmd.Args, gc.DeepEquals, strings.Fields(paccmder.SearchCmd("juju")))
 }
 
 func (s *SnapSuite) TestSearchForUnknownPackage(c *gc.C) {
 	const expected = `error: no snap found for "foo"`
 
 	cmdChan := s.HookCommandOutput(&manager.CommandOutput, []byte(expected), s.mockExitError(1))
-	exists, err := s.pacman.Search("foo")
+
+	paccmder := commands.NewSnapPackageCommander()
+	pacman := manager.NewSnapPackageManager()
+	exists, err := pacman.Search("foo")
 	c.Assert(err, gc.IsNil)
 	c.Assert(exists, jc.IsFalse)
 
 	cmd := <-cmdChan
-	c.Assert(cmd.Args, gc.DeepEquals, strings.Fields(s.paccmder.SearchCmd("foo")))
+	c.Assert(cmd.Args, gc.DeepEquals, strings.Fields(paccmder.SearchCmd("foo")))
 }
 
 func (s *SnapSuite) TestIsInstalled(c *gc.C) {
@@ -172,33 +162,42 @@ juju  2.6.6    8594  2.6       canonical✓  classic
 `
 
 	cmdChan := s.HookCommandOutput(&manager.CommandOutput, []byte(expected), nil)
-	installed := s.pacman.IsInstalled("juju")
+
+	paccmder := commands.NewSnapPackageCommander()
+	pacman := manager.NewSnapPackageManager()
+	installed := pacman.IsInstalled("juju")
 	c.Assert(installed, jc.IsTrue)
 
 	cmd := <-cmdChan
-	c.Assert(cmd.Args, gc.DeepEquals, strings.Fields(s.paccmder.IsInstalledCmd("juju")))
+	c.Assert(cmd.Args, gc.DeepEquals, strings.Fields(paccmder.IsInstalledCmd("juju")))
 }
 
 func (s *SnapSuite) TestIsInstalledForUnknownPackage(c *gc.C) {
 	const expected = `error: no matching snaps installed`
 
 	cmdChan := s.HookCommandOutput(&manager.CommandOutput, []byte(expected), s.mockExitError(1))
-	installed := s.pacman.IsInstalled("foo")
+
+	paccmder := commands.NewSnapPackageCommander()
+	pacman := manager.NewSnapPackageManager()
+	installed := pacman.IsInstalled("foo")
 	c.Assert(installed, jc.IsFalse)
 
 	cmd := <-cmdChan
-	c.Assert(cmd.Args, gc.DeepEquals, strings.Fields(s.paccmder.IsInstalledCmd("foo")))
+	c.Assert(cmd.Args, gc.DeepEquals, strings.Fields(paccmder.IsInstalledCmd("foo")))
 }
 
 func (s *SnapSuite) TestInstall(c *gc.C) {
 	const expected = `juju 2.6.6 from Canonical✓ installed`
 
 	cmdChan := s.HookCommandOutput(&manager.CommandOutput, []byte(expected), nil)
-	err := s.pacman.Install("juju")
+
+	paccmder := commands.NewSnapPackageCommander()
+	pacman := manager.NewSnapPackageManager()
+	err := pacman.Install("juju")
 	c.Assert(err, gc.IsNil)
 
 	cmd := <-cmdChan
-	c.Assert(cmd.Args, gc.DeepEquals, strings.Fields(s.paccmder.InstallCmd("juju")))
+	c.Assert(cmd.Args, gc.DeepEquals, strings.Fields(paccmder.InstallCmd("juju")))
 }
 
 func (s *SnapSuite) TestInstallWithFailure(c *gc.C) {
@@ -206,7 +205,7 @@ func (s *SnapSuite) TestInstallWithFailure(c *gc.C) {
 	var calls int
 	state := os.ProcessState{}
 	cmdError := &exec.ExitError{ProcessState: &state}
-	s.PatchValue(&manager.Attempts, minRetries)
+	s.PatchValue(&manager.SnapAttempts, minRetries)
 	s.PatchValue(&manager.Delay, testing.ShortWait)
 	s.PatchValue(&manager.ProcessStateSys, func(*os.ProcessState) interface{} {
 		return mockExitStatuser(1) // retry each time.
@@ -220,7 +219,8 @@ cannot perform the following tasks:
 		return []byte(output), cmdError
 	})
 
-	err := s.pacman.Install("juju")
+	pacman := manager.NewSnapPackageManager()
+	err := pacman.Install("juju")
 	c.Assert(err, gc.ErrorMatches, `packaging command failed: attempt count exceeded: .*`)
 	c.Assert(calls, gc.Equals, minRetries)
 }
@@ -230,7 +230,7 @@ func (s *SnapSuite) TestInstallWithFailureAndNonMatchingOutput(c *gc.C) {
 	var calls int
 	state := os.ProcessState{}
 	cmdError := &exec.ExitError{ProcessState: &state}
-	s.PatchValue(&manager.Attempts, minRetries)
+	s.PatchValue(&manager.SnapAttempts, minRetries)
 	s.PatchValue(&manager.Delay, testing.ShortWait)
 	s.PatchValue(&manager.ProcessStateSys, func(*os.ProcessState) interface{} {
 		return mockExitStatuser(1) // retry each time.
@@ -246,7 +246,8 @@ func (s *SnapSuite) TestInstallWithFailureAndNonMatchingOutput(c *gc.C) {
 		return output, cmdError
 	})
 
-	err := s.pacman.Install("juju")
+	pacman := manager.NewSnapPackageManager()
+	err := pacman.Install("juju")
 	c.Assert(err, gc.ErrorMatches, `packaging command failed: exit status .*`)
 	c.Assert(calls, gc.Equals, 1)
 }
@@ -256,7 +257,7 @@ func (s *SnapSuite) TestInstallWithoutFailure(c *gc.C) {
 	var calls int
 	state := os.ProcessState{}
 	cmdError := &exec.ExitError{ProcessState: &state}
-	s.PatchValue(&manager.Attempts, minRetries)
+	s.PatchValue(&manager.SnapAttempts, minRetries)
 	s.PatchValue(&manager.Delay, testing.ShortWait)
 	s.PatchValue(&manager.ProcessStateSys, func(*os.ProcessState) interface{} {
 		return mockExitStatuser(0) // retry each time.
@@ -272,7 +273,8 @@ func (s *SnapSuite) TestInstallWithoutFailure(c *gc.C) {
 		return output, cmdError
 	})
 
-	_ = s.pacman.Install("juju")
+	pacman := manager.NewSnapPackageManager()
+	_ = pacman.Install("juju")
 	c.Assert(calls, gc.Equals, 1)
 }
 
@@ -281,7 +283,7 @@ func (s *SnapSuite) TestInstallWithDNSFailure(c *gc.C) {
 	var calls int
 	state := os.ProcessState{}
 	cmdError := &exec.ExitError{ProcessState: &state}
-	s.PatchValue(&manager.Attempts, minRetries)
+	s.PatchValue(&manager.SnapAttempts, minRetries)
 	s.PatchValue(&manager.Delay, testing.ShortWait)
 	s.PatchValue(&manager.ProcessStateSys, func(*os.ProcessState) interface{} {
 		return mockExitStatuser(100) // retry each time.
@@ -297,28 +299,34 @@ func (s *SnapSuite) TestInstallWithDNSFailure(c *gc.C) {
 		return output, cmdError
 	})
 
-	_ = s.pacman.Install("juju")
+	pacman := manager.NewSnapPackageManager()
+	_ = pacman.Install("juju")
 	c.Assert(calls, gc.Equals, 1)
 }
 
 func (s *SnapSuite) TestInstallForUnknownPackage(c *gc.C) {
 	const minRetries = 3
-	s.PatchValue(&manager.Attempts, minRetries)
+	s.PatchValue(&manager.SnapAttempts, minRetries)
 	s.PatchValue(&manager.Delay, testing.ShortWait)
 
 	const expected = `error: snap "foo" not found`
 
 	cmdChan := s.HookCommandOutput(&manager.CommandOutput, []byte(expected), s.mockExitError(1))
-	err := s.pacman.Install("foo")
+
+	paccmder := commands.NewSnapPackageCommander()
+	pacman := manager.NewSnapPackageManager()
+	err := pacman.Install("foo")
 	c.Assert(err, gc.ErrorMatches, ".*unable to locate package")
 
 	cmd := <-cmdChan
-	c.Assert(cmd.Args, gc.DeepEquals, strings.Fields(s.paccmder.InstallCmd("foo")))
+	c.Assert(cmd.Args, gc.DeepEquals, strings.Fields(paccmder.InstallCmd("foo")))
 }
 
 func (s *SnapSuite) TestConfigureProxy(c *gc.C) {
 	cmdChan := s.HookCommandOutput(&manager.CommandOutput, nil, nil)
-	err := s.pacman.ConfigureStoreProxy(snapProxyResponse, "1234567890STOREIDENTIFIER0123456")
+
+	pacman := manager.NewSnapPackageManager()
+	err := pacman.ConfigureStoreProxy(snapProxyResponse, "1234567890STOREIDENTIFIER0123456")
 	c.Assert(err, gc.IsNil)
 
 	ackCmd := <-cmdChan
@@ -330,7 +338,9 @@ func (s *SnapSuite) TestConfigureProxy(c *gc.C) {
 
 func (s *SnapSuite) TestDisableStoreProxy(c *gc.C) {
 	cmdChan := s.HookCommandOutput(&manager.CommandOutput, nil, nil)
-	err := s.pacman.DisableStoreProxy()
+
+	pacman := manager.NewSnapPackageManager()
+	err := pacman.DisableStoreProxy()
 	c.Assert(err, gc.IsNil)
 
 	setCmd := <-cmdChan
@@ -367,7 +377,9 @@ channels:
 installed:       2.6.6                                (8594) 68MB classic
 `
 	cmdChan := s.HookCommandOutput(&manager.CommandOutput, []byte(expected), nil)
-	channel := s.pacman.InstalledChannel("juju")
+
+	pacman := manager.NewSnapPackageManager()
+	channel := pacman.InstalledChannel("juju")
 	c.Assert(channel, gc.Equals, "2.8/bleeding-edge")
 
 	setCmd := <-cmdChan
@@ -403,7 +415,9 @@ channels:
 installed:       2.6.6                                (8594) 68MB classic
 `
 	cmdChan := s.HookCommandOutput(&manager.CommandOutput, []byte(expected), nil)
-	channel := s.pacman.InstalledChannel("juju")
+
+	pacman := manager.NewSnapPackageManager()
+	channel := pacman.InstalledChannel("juju")
 	c.Assert(channel, gc.Equals, "")
 
 	setCmd := <-cmdChan
@@ -413,7 +427,9 @@ installed:       2.6.6                                (8594) 68MB classic
 func (s *SnapSuite) TestChangeChannel(c *gc.C) {
 	const expected = `lxd (candidate) 4.0.0 from Canonical✓ refreshed`
 	cmdChan := s.HookCommandOutput(&manager.CommandOutput, []byte(expected), nil)
-	err := s.pacman.ChangeChannel("lxd", "latest/candidate")
+
+	pacman := manager.NewSnapPackageManager()
+	err := pacman.ChangeChannel("lxd", "latest/candidate")
 	c.Assert(err, jc.ErrorIsNil)
 
 	setCmd := <-cmdChan
@@ -423,7 +439,9 @@ func (s *SnapSuite) TestChangeChannel(c *gc.C) {
 func (s *SnapSuite) TestChangeChannelForNotInstalledSnap(c *gc.C) {
 	const expected = `snap "lxd" is not installed`
 	cmdChan := s.HookCommandOutput(&manager.CommandOutput, []byte(expected), nil)
-	err := s.pacman.ChangeChannel("lxd", "latest/candidate")
+
+	pacman := manager.NewSnapPackageManager()
+	err := pacman.ChangeChannel("lxd", "latest/candidate")
 	c.Assert(err, gc.ErrorMatches, "snap not installed")
 
 	setCmd := <-cmdChan

--- a/manager/snap_test.go
+++ b/manager/snap_test.go
@@ -13,8 +13,8 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/packaging/commands"
-	"github.com/juju/packaging/manager"
+	"github.com/juju/packaging/v2/commands"
+	"github.com/juju/packaging/v2/manager"
 )
 
 var (

--- a/manager/testing/interface_test.go
+++ b/manager/testing/interface_test.go
@@ -5,8 +5,8 @@
 package testing_test
 
 import (
-	"github.com/juju/packaging/manager"
-	"github.com/juju/packaging/manager/testing"
+	"github.com/juju/packaging/v2/manager"
+	"github.com/juju/packaging/v2/manager/testing"
 )
 
 var _ manager.PackageManager = &testing.MockPackageManager{}

--- a/manager/utils_test.go
+++ b/manager/utils_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/juju/testing"
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/packaging/manager"
+	"github.com/juju/packaging/v2/manager"
 )
 
 var _ = gc.Suite(&UtilsSuite{})

--- a/manager/yum.go
+++ b/manager/yum.go
@@ -27,7 +27,8 @@ type yum struct {
 func NewYumPackageManager() PackageManager {
 	manager := &yum{
 		basePackageManager: basePackageManager{
-			cmder: commands.NewYumPackageCommander(),
+			cmder:       commands.NewYumPackageCommander(),
+			retryPolicy: DefaultRetryPolicy(),
 		},
 	}
 	manager.basePackageManager.retryable = manager
@@ -36,7 +37,7 @@ func NewYumPackageManager() PackageManager {
 
 // Search is defined on the PackageManager interface.
 func (yum *yum) Search(pack string) (bool, error) {
-	_, code, err := RunCommandWithRetry(yum.cmder.SearchCmd(pack), yum)
+	_, code, err := RunCommandWithRetry(yum.cmder.SearchCmd(pack), yum, yum.retryPolicy)
 
 	// yum list package returns 1 when it cannot find the package.
 	if code == 1 {

--- a/manager/yum.go
+++ b/manager/yum.go
@@ -9,6 +9,7 @@ import (
 	"os/exec"
 	"strings"
 
+	"github.com/juju/packaging/v2/commands"
 	"github.com/juju/proxy"
 )
 
@@ -17,9 +18,19 @@ type yum struct {
 	basePackageManager
 }
 
+// NewYumPackageManager returns a PackageManager for yum-based systems.
+func NewYumPackageManager() PackageManager {
+	return &yum{
+		basePackageManager: basePackageManager{
+			cmder:     commands.NewYumPackageCommander(),
+			retryable: dnsRetryable{},
+		},
+	}
+}
+
 // Search is defined on the PackageManager interface.
 func (yum *yum) Search(pack string) (bool, error) {
-	_, code, err := RunCommandWithRetry(yum.cmder.SearchCmd(pack), nil)
+	_, code, err := RunCommandWithRetry(yum.cmder.SearchCmd(pack), yum.retryable)
 
 	// yum list package returns 1 when it cannot find the package.
 	if code == 1 {

--- a/manager/yum_test.go
+++ b/manager/yum_test.go
@@ -12,8 +12,8 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/packaging/commands"
-	"github.com/juju/packaging/manager"
+	"github.com/juju/packaging/v2/commands"
+	"github.com/juju/packaging/v2/manager"
 )
 
 var _ = gc.Suite(&YumSuite{})

--- a/manager/zypper.go
+++ b/manager/zypper.go
@@ -9,6 +9,7 @@ import (
 	"os/exec"
 	"strings"
 
+	"github.com/juju/packaging/v2/commands"
 	"github.com/juju/proxy"
 )
 
@@ -17,9 +18,18 @@ type zypper struct {
 	basePackageManager
 }
 
+func NewZypperPackageManager() PackageManager {
+	return &zypper{
+		basePackageManager{
+			cmder:     commands.NewZypperPackageCommander(),
+			retryable: dnsRetryable{},
+		},
+	}
+}
+
 // Search is defined on the PackageManager interface.
 func (zypper *zypper) Search(pack string) (bool, error) {
-	_, code, err := RunCommandWithRetry(zypper.cmder.SearchCmd(pack), nil)
+	_, code, err := RunCommandWithRetry(zypper.cmder.SearchCmd(pack), zypper.retryable)
 
 	// zypper search returns 104 when it cannot find the package.
 	if code == 104 {

--- a/manager/zypper.go
+++ b/manager/zypper.go
@@ -13,7 +13,7 @@ import (
 	"github.com/juju/proxy"
 )
 
-// yum is the PackageManager implementations for rpm-based systems.
+// zypper is the PackageManager implementations for openSUSE systems.
 type zypper struct {
 	basePackageManager
 }
@@ -21,21 +21,19 @@ type zypper struct {
 func NewZypperPackageManager() PackageManager {
 	return &zypper{
 		basePackageManager{
-			cmder:     commands.NewZypperPackageCommander(),
-			retryable: dnsRetryable{},
+			cmder: commands.NewZypperPackageCommander(),
 		},
 	}
 }
 
 // Search is defined on the PackageManager interface.
 func (zypper *zypper) Search(pack string) (bool, error) {
-	_, code, err := RunCommandWithRetry(zypper.cmder.SearchCmd(pack), zypper.retryable)
+	_, code, err := RunCommandWithRetry(zypper.cmder.SearchCmd(pack), zypper)
 
 	// zypper search returns 104 when it cannot find the package.
 	if code == 104 {
 		return false, nil
 	}
-
 	return true, err
 }
 

--- a/manager/zypper.go
+++ b/manager/zypper.go
@@ -19,16 +19,19 @@ type zypper struct {
 }
 
 func NewZypperPackageManager() PackageManager {
+	// Note: this does not override the default retrier, as Zypper doesn't have
+	// any retryable CLI command codes.
 	return &zypper{
 		basePackageManager{
-			cmder: commands.NewZypperPackageCommander(),
+			cmder:       commands.NewZypperPackageCommander(),
+			retryPolicy: DefaultRetryPolicy(),
 		},
 	}
 }
 
 // Search is defined on the PackageManager interface.
 func (zypper *zypper) Search(pack string) (bool, error) {
-	_, code, err := RunCommandWithRetry(zypper.cmder.SearchCmd(pack), zypper)
+	_, code, err := RunCommandWithRetry(zypper.cmder.SearchCmd(pack), zypper, zypper.retryPolicy)
 
 	// zypper search returns 104 when it cannot find the package.
 	if code == 104 {

--- a/manager/zypper_test.go
+++ b/manager/zypper_test.go
@@ -11,8 +11,8 @@ import (
 	jc "github.com/juju/testing/checkers"
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/packaging/commands"
-	"github.com/juju/packaging/manager"
+	"github.com/juju/packaging/v2/commands"
+	"github.com/juju/packaging/v2/manager"
 )
 
 var _ = gc.Suite(&YumSuite{})


### PR DESCRIPTION
The way this worked previously was that it would exit out early if it
wasn't a DNS exit code (100). So for snap installs, this would mean a
retry wouldn't happen as that was a 1.

The code is changed so that we have a set of high-order functions that
allow you to express what we want to achieve from calling the packaging
manager install.

Unfortunately we had to make some breaking changes and bump to v2.

----

The running of a retry command now attempts to split the work into 2
places. The running of the command and if the error is a fatal error.
With this in place we don't need to check for retrying locally and we
can ask each individual package manager if they can retry.

The runner previously had way to much knowledge and pushed apt, yum,
snap and zypper to all behave the same. This isn't the case and not how
each package manager works. See #2 

This simple change, isn't so simple because the tests patch the hell out
of things and calls commands locally on each system, which is confusing.

The changes here try and straighten it all out, but could do with
re-write of the tests as they're observed testing, rather than expected
conditional testing.

Fixes #2 as a driveby.