### PR TITLE
Add max attempts to package manager loop

### DIFF
--- a/config/global_constants.go
+++ b/config/global_constants.go
@@ -7,17 +7,19 @@ package config
 const (
 	// PackageManagerLoopFunction is a bash function that executes its arguments
 	// in a loop with a delay until either the command either returns
-	// with an exit code other than 100.
+	// with an exit code other than 100. It times out after 5 failed attempts.
 	PackageManagerLoopFunction = `
 function package_manager_loop {
+    local attempts=0
     local rc=
     while true; do
+        attempts=$((attempts+1))
         if ($*); then
                 return 0
         else
                 rc=$?
         fi
-        if [ $rc -eq 100 ]; then
+        if [ $attempts -lt 5 -a $rc -eq 100 ]; then
                 sleep 10s
                 continue
         fi


### PR DESCRIPTION
When bootstrapping an LXD controller (or adding a new machine), it tries to `apt-get install` certain dependencies. A problem arises when the new machine cannot connect to the apt archive for whatever reason. The `apt-get install` is run in an infinite loop, and so the bootstrap hangs forever.

This PR adds a max of 5 attempts to the loop, so that the user will get a failure instead of an infinite hang.

## QA steps

Copy this branch to local machine and run 
```
go mod edit -replace=github.com/juju/packaging/v2=<local/path>
make go-build
```
Turn off your internet connection and run
```console
$ juju bootstrap lxd c
...
Running machine configuration script...
...
Err:1 http://archive.ubuntu.com/ubuntu focal/main amd64 msr-tools amd64 1.3-3
  Temporary failure resolving 'archive.ubuntu.com'
Err:2 http://archive.ubuntu.com/ubuntu focal/main amd64 cpu-checker amd64 0.7-1.1
  Temporary failure resolving 'archive.ubuntu.com'
E: Failed to fetch http://archive.ubuntu.com/ubuntu/pool/main/m/msr-tools/msr-tools_1.3-3_amd64.deb  Temporary failure resolving 'archive.ubuntu.com'
E: Failed to fetch http://archive.ubuntu.com/ubuntu/pool/main/c/cpu-checker/cpu-checker_0.7-1.1_amd64.deb  Temporary failure resolving 'archive.ubuntu.com'
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
...
ERROR failed to bootstrap model: subprocess encountered error code 100 
```

## Bug reference

https://bugs.launchpad.net/juju/+bug/1969706
https://bugs.launchpad.net/juju/+bug/1993914